### PR TITLE
Double Transposition Cipher

### DIFF
--- a/double_trans_cipher.rb
+++ b/double_trans_cipher.rb
@@ -1,53 +1,62 @@
+# frozen_string_literal: true
+
+# Double transposition cipher encrypts documents by applying row and column transpositions.
 module DoubleTranspositionCipher
   def self.encrypt(document, key)
+    double_trans(document, key)
+  end
+
+  def self.decrypt(ciphertext, key)
+    plaintext = double_trans(ciphertext, key, reverse: true)
+
+    # Unpad the trailing null bytes
+    plaintext.chop! while plaintext.end_with?("\x00")
+
+    plaintext
+  end
+
+  def self.double_trans(input, key, reverse: false)
     # 1. find number of rows/cols such that matrix is almost square
     # 2. break plaintext into evenly sized blocks
     # 3. sort rows in predictibly random way using key as seed
     # 4. sort columns of each row in predictibly random way
     # 5. return joined cyphertext
 
-    dimensions = Math.sqrt(document.length).ceil
+    dimensions = Math.sqrt(input.length).ceil
 
+    # Pad the input with null bytes
+    padded = input.ljust(dimensions**2, "\x00")
+
+    # Break the input into evenly sized blocks
+    matrix = padded.chars.each_slice(dimensions).map(&:join)
+
+    rows_order, cols_order = get_orders(dimensions, key, reverse: reverse)
+    apply_transposition!(matrix, rows_order, cols_order)
+
+    matrix.join
+  end
+
+  def self.get_orders(dimensions, key, reverse: false)
     rng = Random.new(key)
+
     rows_order = (0...dimensions).to_a.shuffle(random: rng)
     cols_order = (0...dimensions).to_a.shuffle(random: rng)
 
-    # Pad the document with null bytes
-    padded = document.ljust(dimensions * dimensions, "\x00")
+    if reverse
+      rev_rows_order = rows_order.each_with_index.sort.map(&:last)
+      rev_cols_order = cols_order.each_with_index.sort.map(&:last)
 
-    # Split the document into evenly sized blocks
-    ciphertext = padded.chars.each_slice(dimensions).map(&:join)
-
-    # Apply the row order
-    ciphertext = rows_order.map { |i| ciphertext[i] }
-
-    # Apply the column order in each row
-    ciphertext.map! { |row| cols_order.map { |i| row[i] }.join }
-
-    ciphertext.join
+      [rev_rows_order, rev_cols_order]
+    else
+      [rows_order, cols_order]
+    end
   end
 
-  def self.decrypt(ciphertext, key)
-    dimensions = Math.sqrt(ciphertext.length).ceil
+  def self.apply_transposition!(matrix, rows_order, cols_order)
+    # Apply row order
+    matrix = rows_order.map { |i| matrix[i] }
 
-    rng = Random.new(key)
-    rev_rows_order = (0...dimensions).to_a.shuffle(random: rng).each_with_index.sort.map(&:last)
-    rev_cols_order = (0...dimensions).to_a.shuffle(random: rng).each_with_index.sort.map(&:last)
-
-    # Split the ciphertext into evenly sized blocks
-    plaintext = ciphertext.chars.each_slice(dimensions).map(&:join)
-
-    # Apply the reverse row order
-    plaintext = rev_rows_order.map { |i| plaintext[i] }
-
-    # Apply the reverse column order in each row
-    plaintext.map! { |row| rev_cols_order.map { |i| row[i] }.join }
-
-    plaintext = plaintext.join
-
-    # Unpad the trailing null bytes
-    plaintext.chop! while plaintext.end_with?("\x00")
-
-    plaintext
+    # Apply column order in each row
+    matrix.map! { |row| cols_order.map { |i| row[i] } }
   end
 end

--- a/double_trans_cipher.rb
+++ b/double_trans_cipher.rb
@@ -1,15 +1,53 @@
 module DoubleTranspositionCipher
   def self.encrypt(document, key)
-    # TODO: FILL THIS IN!
-    ## Suggested steps for double transposition cipher
     # 1. find number of rows/cols such that matrix is almost square
     # 2. break plaintext into evenly sized blocks
     # 3. sort rows in predictibly random way using key as seed
     # 4. sort columns of each row in predictibly random way
     # 5. return joined cyphertext
+
+    dimensions = Math.sqrt(document.length).ceil
+
+    rng = Random.new(key)
+    rows_order = (0...dimensions).to_a.shuffle(random: rng)
+    cols_order = (0...dimensions).to_a.shuffle(random: rng)
+
+    # Pad the document with null bytes
+    padded = document.ljust(dimensions * dimensions, "\x00")
+
+    # Split the document into evenly sized blocks
+    ciphertext = padded.chars.each_slice(dimensions).map(&:join)
+
+    # Apply the row order
+    ciphertext = rows_order.map { |i| ciphertext[i] }
+
+    # Apply the column order in each row
+    ciphertext.map! { |row| cols_order.map { |i| row[i] }.join }
+
+    ciphertext.join
   end
 
   def self.decrypt(ciphertext, key)
-    # TODO: FILL THIS IN!
+    dimensions = Math.sqrt(ciphertext.length).ceil
+
+    rng = Random.new(key)
+    rev_rows_order = (0...dimensions).to_a.shuffle(random: rng).each_with_index.sort.map(&:last)
+    rev_cols_order = (0...dimensions).to_a.shuffle(random: rng).each_with_index.sort.map(&:last)
+
+    # Split the ciphertext into evenly sized blocks
+    plaintext = ciphertext.chars.each_slice(dimensions).map(&:join)
+
+    # Apply the reverse row order
+    plaintext = rev_rows_order.map { |i| plaintext[i] }
+
+    # Apply the reverse column order in each row
+    plaintext.map! { |row| rev_cols_order.map { |i| row[i] }.join }
+
+    plaintext = plaintext.join
+
+    # Unpad the trailing null bytes
+    plaintext.chop! while plaintext.end_with?("\x00")
+
+    plaintext
   end
 end

--- a/spec/crypto_spec.rb
+++ b/spec/crypto_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative '../credit_card'
 require_relative '../substitution_cipher'
+require_relative '../double_trans_cipher'
 require 'minitest/autorun'
 
 describe 'Test card info encryption' do
@@ -41,4 +42,18 @@ describe 'Test card info encryption' do
 
   # TODO: Add tests for double transposition and modern symmetric key ciphers
   #       Can you DRY out the tests using metaprogramming? (see lecture slide)
+
+  describe 'Using Double Transposition cipher' do
+    it 'should encrypt card information' do
+      enc = DoubleTranspositionCipher.encrypt(@cc.to_s, @key)
+      _(enc).wont_equal @cc.to_s
+      _(enc).wont_be_nil
+    end
+
+    it 'should decrypt text' do
+      enc = DoubleTranspositionCipher.encrypt(@cc.to_s, @key)
+      dec = DoubleTranspositionCipher.decrypt(enc, @key)
+      _(dec).must_equal @cc.to_s
+    end
+  end
 end


### PR DESCRIPTION
- Implement decode & encode methods
- Split methods into smaller helper methods, reusing code in both encryption & decryption and reducing ABC
- Add test for double trans cipher

Closes #4 